### PR TITLE
Mention alert spam for failed Jobs

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -441,15 +441,15 @@ General deployment alerts
 - Remaining TLS certificate lifetime for each important public-facing site less than some threshold (30 days?)
 - Remaining Kubernetes control plane TLS certificate lifetime less than some threshold for every Kubernetes cluster (will require per-cluster monitoring infrastructure or some agent in each cluster that calls out to the monitoring system, due to firewalls)
 - Remaining lifetime of the tokens for our Vault service accounts
-- Argo CD applications in failed state
+- Argo CD applications in failed state (however, we should avoid alerting for a ``Job`` in a failed state if there is a newer execution of that ``Job`` that succeeded, and avoid alerting multiple times for the same failed ``Job``)
 
 Specific applications
 `````````````````````
 
-- cachemachine failure to pre-pull images after more than some threshold of time
+- Nublado controller failure to pre-pull images after more than some threshold of time
 - cert-manager fails to refresh a desired certificate
 - vault-secrets-operator fails to refresh a desired secret
-- neophile processing failed or produced errors on for a package
+- Package fails to pass its tests if its dependencies are updated
 
 Validation alerts
 `````````````````

--- a/technote.toml
+++ b/technote.toml
@@ -7,6 +7,7 @@ github_default_branch = "main"
 organization.name = "Vera C. Rubin Observatory"
 organization.ror = "https://ror.org/048g3cy84"
 license.id = "CC-BY-4.0"
+
 [[technote.authors]]
 name = {given = "Frossie", family = "Economou"}
 internal_id = "economouf"
@@ -32,6 +33,7 @@ orcid = "https://orcid.org/0000-0001-9342-6032"
 name = "Rubin Observatory Project Office"
 internal_id = "RubinObs"
 address = "950 N. Cherry Ave., Tucson, AZ 85719, USA"
+
 [[technote.authors]]
 name = {given = "Jonathan", family = "Sick"}
 internal_id = "sickj"


### PR DESCRIPTION
Note that we should avoid alerting multiple times for the same failed Job, or alerting if a newer version of the same Job did succeed.